### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/Build-ArduinoIDE-T-ETH-ELite-ESP32S3.yml
+++ b/.github/workflows/Build-ArduinoIDE-T-ETH-ELite-ESP32S3.yml
@@ -59,7 +59,7 @@ jobs:
       EXAMPLES: ${{matrix.examples}}
       ENV: 'T-ETH-ELite-ESP32S3'
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
 
       - name: Install Arduino Ci
         run: |

--- a/.github/workflows/Build-ArduinoIDE-T-ETH-Lite-ESP32.yml
+++ b/.github/workflows/Build-ArduinoIDE-T-ETH-Lite-ESP32.yml
@@ -47,7 +47,7 @@ jobs:
       EXAMPLES: ${{matrix.examples}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Install Arduino Ci
         run: |
           wget https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_64bit.tar.gz -O arduino-cli.tar.gz ;

--- a/.github/workflows/Build-ArduinoIDE-T-ETH-Lite-ESP32S3.yml
+++ b/.github/workflows/Build-ArduinoIDE-T-ETH-Lite-ESP32S3.yml
@@ -47,7 +47,7 @@ jobs:
       EXAMPLES: ${{matrix.examples}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Install Arduino Ci
         run: |
           wget https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_64bit.tar.gz -O arduino-cli.tar.gz ;

--- a/.github/workflows/Build-ArduinoIDE-T-ETH-POE-PRO.yml
+++ b/.github/workflows/Build-ArduinoIDE-T-ETH-POE-PRO.yml
@@ -47,7 +47,7 @@ jobs:
       EXAMPLES: ${{matrix.examples}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Install Arduino Ci
         run: |
           wget https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_64bit.tar.gz -O arduino-cli.tar.gz ;

--- a/.github/workflows/Build-ArduinoIDE-T-ETH-POE.yml
+++ b/.github/workflows/Build-ArduinoIDE-T-ETH-POE.yml
@@ -47,7 +47,7 @@ jobs:
       EXAMPLES: ${{matrix.examples}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Install Arduino Ci
         run: |
           wget https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_64bit.tar.gz -O arduino-cli.tar.gz ;

--- a/.github/workflows/Build-ArduinoIDE-T-INTERNET-COM.yml
+++ b/.github/workflows/Build-ArduinoIDE-T-INTERNET-COM.yml
@@ -48,7 +48,7 @@ jobs:
       EXAMPLES: ${{matrix.examples}}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - name: Install Arduino Ci
         run: |
           wget https://downloads.arduino.cc/arduino-cli/arduino-cli_latest_Linux_64bit.tar.gz -O arduino-cli.tar.gz ;

--- a/.github/workflows/Build-T-ETH-ELite-ESP32-S3.yml
+++ b/.github/workflows/Build-T-ETH-ELite-ESP32-S3.yml
@@ -59,14 +59,14 @@ jobs:
     env:
         ENV: 'T-ETH-ELite-ESP32S3'
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v6
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
           key: ${{ runner.os }}-pio
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.9"
       - name: Install PlatformIO Core

--- a/.github/workflows/Build-T-ETH-Lite-ESP32-S3.yml
+++ b/.github/workflows/Build-T-ETH-Lite-ESP32-S3.yml
@@ -45,14 +45,14 @@ jobs:
           - examples/WireExample
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v6
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
           key: ${{ runner.os }}-pio
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.9"
       - name: Install PlatformIO Core

--- a/.github/workflows/Build-T-ETH-Lite-ESP32.yml
+++ b/.github/workflows/Build-T-ETH-Lite-ESP32.yml
@@ -45,14 +45,14 @@ jobs:
           - examples/WireExample
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v6
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
           key: ${{ runner.os }}-pio
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.9"
       - name: Install PlatformIO Core

--- a/.github/workflows/Build-T-ETH-POE-PRO.yml
+++ b/.github/workflows/Build-T-ETH-POE-PRO.yml
@@ -45,14 +45,14 @@ jobs:
           - examples/WireExample
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v6
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
           key: ${{ runner.os }}-pio
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.9"
       - name: Install PlatformIO Core

--- a/.github/workflows/Build-T-ETH-POE.yml
+++ b/.github/workflows/Build-T-ETH-POE.yml
@@ -45,14 +45,14 @@ jobs:
           - examples/WireExample
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v6
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
           key: ${{ runner.os }}-pio
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.9"
       - name: Install PlatformIO Core

--- a/.github/workflows/Build-T-INTERNET-COM.yml
+++ b/.github/workflows/Build-T-INTERNET-COM.yml
@@ -46,14 +46,14 @@ jobs:
           - examples/InternetComTest
 
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/cache@v3
+      - uses: actions/checkout@v6
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.cache/pip
             ~/.platformio/.cache
           key: ${{ runner.os }}-pio
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.9"
       - name: Install PlatformIO Core

--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -10,7 +10,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v5
+      - uses: actions/stale@v10
         with:
           days-before-issue-stale: 30
           days-before-issue-close: 14


### PR DESCRIPTION
Updated all GitHub Actions workflow dependencies to their latest major versions.

| Action                 | Old | New |
|------------------------|-----|-----|
| `actions/checkout`     | v3  | v6  |
| `actions/cache`        | v3  | v5  |
| `actions/setup-python` | v4  | v6  |
| `actions/stale`        | v5  | v10 |